### PR TITLE
Rename to Climate Connectivity Taxonomy

### DIFF
--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -19,9 +19,9 @@ sed -i.bak -e '/^:unesco /,/^ *\.$/d' -e '/^:stw /,/^ *\.$/d' skosmos-src/docker
 
 # Append the vocabulary block info
 cat <<'EOF' >> skosmos-src/dockerfiles/config/config-docker-compose.ttl
-:MAIA a skosmos:Vocabulary, void:Dataset ;
-  dc:title "MAIA"@en ;
-  skosmos:shortName "MAIA" ;
+:CCTaxonomy a skosmos:Vocabulary, void:Dataset ;
+  dc:title "Climate Connectivity Taxonomy"@en ;
+  skosmos:shortName "CC Taxonomy" ;
   skosmos:defaultLanguage "en" ;
   void:uriSpace "http://connectivity-hub.com/terms/" ;
   skosmos:sparqlEndpoint <http://fuseki:3030/skosmos/sparql> ;

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Build and deploy MAIA taxonomy to GitHub Pages
+name: Build and deploy Climate Connectivity Taxonomy to GitHub Pages
 
 # Builds a static SkoHub Vocabs site from the raw concepts.ttl export and
 # publishes it to GitHub Pages. The raw export stays untouched in the repo;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,15 +4,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-`maia` (repo `FAIR2Adapt/maia`) holds the **MAIA taxonomy** — a SKOS vocabulary — plus the
-tooling to preview it with [Skosmos](https://github.com/NatLibFi/Skosmos). It is part of the
-FAIR2Adapt workspace and is related to `weADAPT-connectivity-hub/`: the taxonomy lives upstream
-at the connectivity-hub and is mirrored here for browsing/editing.
+Repo `FAIR2Adapt/climate-connectivity-taxonomy` holds the **Climate Connectivity Taxonomy**
+(CC Taxonomy; formerly "MAIA taxonomy") — a SKOS vocabulary — plus the tooling to preview it with
+[Skosmos](https://github.com/NatLibFi/Skosmos). It is part of the FAIR2Adapt workspace and is
+related to `weADAPT-connectivity-hub/`: the taxonomy lives upstream at the connectivity-hub and is
+mirrored here for browsing/editing. (The local working directory may still be named `maia`.)
 
 The repo has **two independent data paths**, and it is important not to confuse them:
 
 - **Public site** (`.github/workflows/pages.yml` → GitHub Pages at
-  `https://fair2adapt.github.io/maia/`). This does **not** use the committed `concepts.ttl`.
+  `https://fair2adapt.github.io/climate-connectivity-taxonomy/`). This does **not** use the
+  committed `concepts.ttl`.
   It fetches the *complete* vocabulary live from the hub, normalises it, and builds a static
   [SkoHub Vocabs](https://github.com/skohub-io/skohub-vocabs) site. See "Public site pipeline".
 - **Internal preview** (the `.devcontainer/` Codespace). This *does* use the committed
@@ -37,7 +39,9 @@ The published site is built by, in order:
 3. SkoHub builds the site via the **`skohub/skohub-vocabs-docker:latest`** image (Node 18; the
    local `npm` build fails on Node ≥ 20 because of Gatsby's bundled `lmdb`/`msgpackr`). The image
    is `linux/amd64`-only — fine on GitHub runners; add `--platform linux/amd64` to run it on Apple
-   Silicon. `BASEURL=/maia` sets the Pages path prefix. `config.yaml` holds the SkoHub config.
+   Silicon. `BASEURL` (derived from the repo name, e.g. `/climate-connectivity-taxonomy`) sets the
+   Pages path prefix. `config.yaml` holds the SkoHub config (UI title = "Climate Connectivity
+   Taxonomy"); `prepare_vocab.py` also rewrites the scheme title if it still says "MAIA".
 
 Refresh the site after the taxonomy changes: re-run the workflow (Actions → Run workflow) or wait
 for the weekly cron. It always pulls the live vocabulary.
@@ -52,7 +56,8 @@ the snapshot commit step will fail (the site still deploys).
 ## The two moving parts
 
 1. **`concepts.ttl`** — the entire vocabulary in one Turtle file (~2.7 MB). It is the
-   `skos:ConceptScheme` `<http://connectivity-hub.com/terms/>` (title "MAIA taxonomy") followed
+   `skos:ConceptScheme` `<http://connectivity-hub.com/terms/>` (hub title currently "MAIA taxonomy",
+   rewritten to "Climate Connectivity Taxonomy" by `prepare_vocab.py`) followed
    by every `skos:Concept`. Concept URIs are `http://connectivity-hub.com/terms/<uuid>`. This is
    the file loaded into the triplestore for preview, so editing the vocabulary = editing this file
    (or regenerating it, see below).
@@ -77,7 +82,7 @@ checkout. The flow, driven by `devcontainer.json`:
 - **`postCreate.sh`** (postCreateCommand) does the real work:
   - clones Skosmos into `skosmos-src/` (gitignored / untracked),
   - edits `skosmos-src/dockerfiles/config/config-docker-compose.ttl`: deletes the bundled
-    `:unesco` / `:stw` demo vocab blocks, appends a `:MAIA` `skosmos:Vocabulary` block pointing at
+    `:unesco` / `:stw` demo vocab blocks, appends a `:CCTaxonomy` `skosmos:Vocabulary` block pointing at
     the Fuseki SPARQL endpoint and graph `http://example.org/graph/dev`, and rewrites
     `skosmos:baseHref` to the Codespace's public `-9090` URL,
   - waits for the Docker daemon, brings up `docker compose -f skosmos-src/docker-compose.yml`

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# MAIA taxonomy
+# Climate Connectivity Taxonomy
 
 ## Browse the taxonomy online
 
-The MAIA taxonomy is published as a static, browsable website on GitHub Pages:
+The Climate Connectivity Taxonomy (CC Taxonomy) is published as a static,
+browsable website on GitHub Pages:
 
-**https://fair2adapt.github.io/maia/**
+**https://fair2adapt.github.io/climate-connectivity-taxonomy/**
 
 The site is built automatically by [`.github/workflows/pages.yml`](.github/workflows/pages.yml):
 
@@ -17,8 +18,8 @@ The site is built automatically by [`.github/workflows/pages.yml`](.github/workf
 3. SkoHub builds the static site and it is deployed to GitHub Pages.
 
 **To refresh the published site after the taxonomy changes in the hub:** just
-re-run the workflow — *Actions → "Build and deploy MAIA taxonomy to GitHub
-Pages" → Run workflow*. It also refreshes automatically every Monday. The
+re-run the workflow — *Actions → "Build and deploy Climate Connectivity
+Taxonomy to GitHub Pages" → Run workflow*. It also refreshes automatically every Monday. The
 pipeline always pulls the live vocabulary; you don't need to edit anything.
 
 After each run the workflow commits the exact vocabulary it fetched back to

--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ searchableAttributes:
   - "definition"
   - "scopeNote"
 ui:
-  title: "MAIA taxonomy" # Title is mandatory
+  title: "Climate Connectivity Taxonomy" # Title is mandatory
   logo: "skohub-signet-color.svg" # Path
   colors:
     skoHubWhite: "rgb(255, 255, 255)"

--- a/scripts/fetch_vocab.py
+++ b/scripts/fetch_vocab.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fetch the *complete* MAIA taxonomy from the connectivity-hub.
+"""Fetch the *complete* Climate Connectivity Taxonomy from the connectivity-hub.
 
 The previous exporter only downloaded the concepts listed in the scheme's
 skos:hasTopConcept, which drops every child concept (anything reachable only via

--- a/scripts/prepare_vocab.py
+++ b/scripts/prepare_vocab.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Normalise the raw MAIA taxonomy export so SkoHub Vocabs can build a good site.
+"""Normalise the raw Climate Connectivity Taxonomy export so SkoHub Vocabs can build a good site.
 
 The vocabulary is exported from the connectivity-hub as-is ("dirty"): it has no
 licence, every concept is flagged as a top concept (so no hierarchy shows), and a
@@ -19,8 +19,14 @@ from rdflib import Graph, Literal, URIRef
 from rdflib.namespace import DCTERMS, RDF, SKOS
 
 # Licence applied to the concept scheme when it has none. Change here (or pass a
-# third CLI arg) if the official MAIA licence differs.
+# third CLI arg) if the official licence differs.
 DEFAULT_LICENSE = URIRef("https://creativecommons.org/licenses/by/4.0/")
+
+# The vocabulary was renamed from "MAIA taxonomy" to "Climate Connectivity
+# Taxonomy". Until the hub itself is updated, rewrite any scheme title still
+# carrying the old name. This is a no-op once the hub serves the new name.
+OLD_TITLE_MARKER = "MAIA"
+NEW_TITLE = "Climate Connectivity Taxonomy"
 
 # Predicates that SkoHub treats as one value per language (a LanguageMap). If the
 # export carries several values in the same language, we keep the longest one so
@@ -32,6 +38,19 @@ SINGLE_VALUED_PER_LANG = [
     DCTERMS.title,
     DCTERMS.description,
 ]
+
+
+def rename_scheme(g: Graph) -> int:
+    """Replace any scheme title still containing the old name with NEW_TITLE."""
+    renamed = 0
+    for scheme in g.subjects(RDF.type, SKOS.ConceptScheme):
+        for predicate in (DCTERMS.title, SKOS.prefLabel):
+            for obj in list(g.objects(scheme, predicate)):
+                if isinstance(obj, Literal) and OLD_TITLE_MARKER in str(obj):
+                    g.remove((scheme, predicate, obj))
+                    g.add((scheme, predicate, Literal(NEW_TITLE, lang=obj.language or "en")))
+                    renamed += 1
+    return renamed
 
 
 def add_license(g: Graph) -> int:
@@ -116,6 +135,7 @@ def main() -> None:
     g.parse(src, format="turtle")
     before = len(g)
 
+    renamed = rename_scheme(g)
     licenses = add_license(g)
     demoted, promoted = normalise_hierarchy(g)
     deduped = dedupe_language_maps(g)
@@ -123,6 +143,7 @@ def main() -> None:
     g.serialize(destination=dst, format="turtle")
 
     print(f"parsed {before} triples from {src}")
+    print(f"  renamed {renamed} scheme title(s) to '{NEW_TITLE}'")
     print(f"  licence added to {licenses} scheme(s)")
     print(f"  hierarchy: demoted {demoted} child concept(s) from top level, "
           f"promoted {promoted} root(s)")


### PR DESCRIPTION
Rebrands the vocabulary from "MAIA taxonomy" to **Climate Connectivity Taxonomy** (short: **CC Taxonomy**) and removes the MAIA name, per Sukaina's request.

- Site UI title (`config.yaml`), workflow name, Skosmos preview block, README, CLAUDE.md.
- `prepare_vocab.py` rewrites the scheme title to the new name while the hub still serves "MAIA" (no-op once the hub is renamed).
- The repo has been renamed to `climate-connectivity-taxonomy`; the published site moves to https://fair2adapt.github.io/climate-connectivity-taxonomy/ (path prefix is derived from the repo name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)