### PR TITLE
Sort and align the SkoHub navigation tree

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -82,6 +82,19 @@ jobs:
             -v "$PWD/config.yaml:/app/config.yaml" \
             skohub/skohub-vocabs-docker:latest
 
+      - name: Sort the navigation tree alphabetically
+        # SkoHub renders the nav tree in the JSON's array order, with no sorting of
+        # its own, so the ~1000 top concepts and their children come out unordered
+        # and structured branches are hard to find by browsing. Sort every
+        # hasTopConcept/narrower array in the built output by prefLabel.
+        run: python scripts/sort_tree.py public
+
+      - name: Fix the navigation tree indentation
+        # SkoHub indents parent rows ~25px past their leaf siblings (the expand
+        # toggle is an in-row flex child), so an expanded parent looks nested under
+        # the leaf above it. Inject CSS that aligns leaf rows with their siblings.
+        run: python scripts/fix_tree_indent.py public
+
       - uses: actions/upload-pages-artifact@v3
         with:
           path: public

--- a/scripts/fix_tree_indent.py
+++ b/scripts/fix_tree_indent.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Fix the SkoHub navigation-tree indentation in the built site.
+
+SkoHub renders each tree row as a flexbox `<li>` where the expand/collapse toggle
+button only exists on concepts that *have* children (see nestedList.jsx upstream).
+Because the button is an in-row flex child (~25px wide), a parent concept's label is
+pushed ~25px to the right of its leaf siblings, so an expanded parent (e.g.
+"Uncertainty") looks like it is nested *under* the leaf directly above it (e.g.
+"Adaptation revenues") even though they are siblings. See the Climate Connectivity
+Taxonomy issue where Uncertainty appeared under Adaptation revenues.
+
+We can't patch the (prebuilt) SkoHub image, so we inject a small CSS rule into every
+built HTML page that gives leaf rows the same left offset as the toggle, lining all
+siblings up. Uses :has() (widely supported) to target rows that lack a toggle button.
+
+Idempotent: pages already carrying the marker are skipped.
+
+Usage:
+    python scripts/fix_tree_indent.py public
+"""
+
+import sys
+from pathlib import Path
+
+MARKER = "cct-tree-indent-fix"
+# 25px = toggle button width (20px) + its margin-right (5px), from nestedList.jsx.
+STYLE = (
+    f'<style id="{MARKER}">'
+    ".concepts li:not(:has(> button.treeItemIcon)) > div{margin-left:25px}"
+    "</style>"
+)
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        sys.exit(f"usage: {sys.argv[0]} PUBLIC_DIR")
+    root = Path(sys.argv[1])
+
+    seen = patched = 0
+    for path in root.rglob("*.html"):
+        if not path.is_file():  # Gatsby creates dirs literally named "404.html"
+            continue
+        html = path.read_text(encoding="utf-8")
+        seen += 1
+        if MARKER in html or "</head>" not in html:
+            continue
+        path.write_text(html.replace("</head>", STYLE + "</head>", 1),
+                        encoding="utf-8")
+        patched += 1
+    print(f"scanned {seen} HTML file(s); injected tree-indent CSS into {patched}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sort_tree.py
+++ b/scripts/sort_tree.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Sort the SkoHub tree alphabetically after the site is built.
+
+SkoHub renders the left-hand navigation tree straight from the order of the
+`hasTopConcept` / `narrower` arrays in the generated JSON, with no sorting of its
+own (see src/templates/App.jsx + src/components/nestedList.jsx upstream). The
+arrays come out in Gatsby's node-processing order, which is effectively arbitrary,
+so ~1000 top concepts and their children appear unordered and structured branches
+are hard to find by browsing.
+
+This walks the built `public/` directory and sorts every `hasTopConcept` and
+`narrower` array by prefLabel (case-insensitively, by the chosen UI language with a
+fallback to any available label), recursively. It touches the fetched tree file
+(`<scheme>/index.json`) *and* the baked Gatsby `page-data.json` files, so the tree
+is sorted both on the concept-scheme landing page and once a concept is opened.
+
+Usage:
+    python scripts/sort_tree.py public [LANG]   # LANG defaults to "en"
+"""
+
+import json
+import sys
+from pathlib import Path
+
+SORT_KEYS = ("hasTopConcept", "narrower")
+
+
+def label(node: dict, lang: str) -> str:
+    """Best-effort prefLabel for sorting: chosen language, else any, else id."""
+    pl = node.get("prefLabel")
+    if isinstance(pl, dict) and pl:
+        val = pl.get(lang) or next(iter(pl.values()))
+        if isinstance(val, str):
+            return val.casefold()
+    if isinstance(pl, str):
+        return pl.casefold()
+    return str(node.get("id", "")).casefold()
+
+
+def sort_node(node, lang: str) -> int:
+    """Recursively sort tree arrays in-place. Returns how many arrays it sorted."""
+    sorted_count = 0
+    if isinstance(node, list):
+        for item in node:
+            sorted_count += sort_node(item, lang)
+    elif isinstance(node, dict):
+        for key, value in node.items():
+            if key in SORT_KEYS and isinstance(value, list):
+                value.sort(key=lambda n: label(n, lang) if isinstance(n, dict) else "")
+                sorted_count += 1
+            sorted_count += sort_node(value, lang)
+    return sorted_count
+
+
+def main() -> None:
+    if not 2 <= len(sys.argv) <= 3:
+        sys.exit(f"usage: {sys.argv[0]} PUBLIC_DIR [LANG]")
+    root = Path(sys.argv[1])
+    lang = sys.argv[2] if len(sys.argv) == 3 else "en"
+
+    files = changed = arrays = 0
+    for path in root.rglob("*.json"):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        files += 1
+        n = sort_node(data, lang)
+        if n:
+            path.write_text(
+                json.dumps(data, ensure_ascii=False, separators=(",", ":")),
+                encoding="utf-8",
+            )
+            changed += 1
+            arrays += n
+    print(f"scanned {files} JSON file(s); sorted {arrays} tree array(s) "
+          f"in {changed} file(s) by prefLabel[{lang}]")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes two SkoHub navigation-tree display issues reported by the taxonomy team (Sukaina & Barbara).

## Problem
SkoHub renders the tree in raw data order and indents parent rows ~25px past their leaf siblings (the expand toggle is an in-row flex child). Result:
- ~1000 top concepts appear unordered, so structured branches are hard to find by browsing.
- An expanded branch looks nested under the leaf above it — e.g. **Uncertainty** appeared to sit under **Adaptation revenues**, when both are siblings under **Financing**. The data (Graphologi + hub) was always correct; this is a SkoHub rendering bug.

## Fix
We use the prebuilt SkoHub image, so both are fixed as post-build steps in `pages.yml`:
- `scripts/sort_tree.py` — sort every `hasTopConcept`/`narrower` array by prefLabel
- `scripts/fix_tree_indent.py` — inject CSS aligning leaf rows with their siblings

Verified locally with a real SkoHub build + headless-Chrome screenshots (before/after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)