### PR TITLE
Fix search: show a matched concept's subtree in the nav tree

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,12 +54,21 @@ jobs:
           # with that path prefix (SkoHub reads it from BASEURL).
           echo "BASEURL=/${GITHUB_REPOSITORY#*/}" > .env
           mkdir -p public && chmod 777 public
+          # The image builds the site with Gatsby at run time (CMD `npm run
+          # container-build`, source under /app). We override the entrypoint to
+          # first apply scripts/patch_search_tree.sh — which fixes SkoHub's search
+          # so a matched parent concept shows its subtree — and then run that same
+          # build. The patch hard-fails if the upstream source moved, so a broken
+          # patch stops the deploy instead of silently shipping the old behaviour.
           docker run --rm \
+            --entrypoint /bin/sh \
             -v "$PWD/public:/app/public" \
             -v "$PWD/data:/app/data" \
             -v "$PWD/.env:/app/.env" \
             -v "$PWD/config.yaml:/app/config.yaml" \
-            skohub/skohub-vocabs-docker:latest
+            -v "$PWD/scripts/patch_search_tree.sh:/tmp/patch_search_tree.sh:ro" \
+            skohub/skohub-vocabs-docker:latest \
+            -c "sh /tmp/patch_search_tree.sh && npm run container-build"
 
       - name: Reclaim ownership of the built site
         # The SkoHub container runs as root, so it writes public/ as root. The

--- a/scripts/patch_search_tree.sh
+++ b/scripts/patch_search_tree.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# Patch SkoHub's navigation-tree component so that a concept which *itself* matches
+# the search query shows its full subtree, instead of having its (non-matching)
+# children pruned away.
+#
+# WHY. SkoHub renders the left nav tree from src/components/nestedList.jsx. When a
+# search is active it filters the tree to only the branches that contain a match and
+# passes that same filter down into every child list. A parent concept whose own
+# prefLabel matches (e.g. "Barriers and enablers") is therefore shown, but each of
+# its children is filtered out unless the child *also* matches the query — so the
+# node renders in its "expanded" state with nothing beneath it. To the user the hit
+# looks un-expandable / dead, even though its name still links to the concept page.
+# See the reported issue: searching "Barriers and enablers" shows the term with no
+# children and no working expand toggle.
+#
+# FIX. In the child recursion, if the current item is itself a direct search match
+# (its id is in the flattened FlexSearch result set) render its children WITHOUT the
+# filter, so the whole subtree shows and stays browsable. Branches that are only in
+# the tree because a *descendant* matched keep the filter, so an unrelated deep match
+# still narrows the tree as before.
+#
+# HOW. skohub/skohub-vocabs-docker builds the site with Gatsby at `docker run` time
+# (CMD `npm run container-build`, source at /app), so this runs inside the container
+# just before that build — see .github/workflows/pages.yml. It rewrites exactly one
+# line and is version-robust: it recomputes the match set inline from the `queryFilter`
+# prop rather than depending on the `filteredIds` local, and it hard-fails if the
+# target line is missing or not unique (i.e. upstream changed and the patch needs a
+# re-check) rather than silently shipping an unpatched site.
+set -eu
+
+f=/app/src/components/nestedList.jsx
+needle='queryFilter={queryFilter}'
+# A concept is a direct match iff its id is in any field's result list.
+replacement='queryFilter={queryFilter && queryFilter.flatMap((f) => f.result).includes(item.id) ? null : queryFilter}'
+
+if [ ! -f "$f" ]; then
+  echo "PATCH ERROR: $f not found — the skohub-vocabs image layout changed." >&2
+  exit 1
+fi
+
+count=$(grep -F -c "$needle" "$f" || true)
+if [ "$count" != "1" ]; then
+  echo "PATCH ERROR: expected exactly 1 occurrence of '$needle' in $f, found ${count}." >&2
+  echo "Upstream SkoHub changed; re-check scripts/patch_search_tree.sh against the new source." >&2
+  exit 1
+fi
+
+# Literal (non-regex) single-line replace via awk, to avoid escaping the { } & in sed.
+awk -v needle="$needle" -v repl="$replacement" '
+  {
+    idx = index($0, needle)
+    if (idx > 0) {
+      $0 = substr($0, 1, idx - 1) repl substr($0, idx + length(needle))
+    }
+    print
+  }
+' "$f" > "$f.patched" && mv "$f.patched" "$f"
+
+if ! grep -F "flatMap((f) => f.result).includes(item.id)" "$f" >/dev/null; then
+  echo "PATCH ERROR: verification failed — replacement not present after edit." >&2
+  exit 1
+fi
+
+echo "PATCH OK: matched-parent subtree fix applied to $f"


### PR DESCRIPTION
## Problem

Reported by a reviewer: searching for a term that exists in the vocabulary — e.g. **"Barriers and enablers"** — shows the concept in the left tree but with **no children and no working expand toggle**, unlike the full (unsearched) listing where it expands normally.

## Root cause (SkoHub, not our data or scripts)

SkoHub's `src/components/nestedList.jsx` treats search as a **tree filter**: it keeps only the branches that contain a match and passes that same filter down into every child list. When the match is a **parent** concept:

- the parent is kept (its own label matched), and while a search is active every node is forced into its **expanded** state, but
- each of its children is filtered out unless the child *also* contains the query string.

So "Barriers and enablers" (which has 3 real `skos:narrower` children, none of which contain the word "barriers") renders as an expanded node with an empty body — the circular icon is a **minus**, not a missing plus, and the name is still a working link (that's why the detail panel loads). This is upstream behaviour, present in `main` as of 2026‑07‑02, so bumping the image does not fix it.

## Fix

Patch one line of `nestedList.jsx` so that a concept which is **itself** a direct search match renders its children **unfiltered** — its full subtree shows and stays browsable. Branches that are only in the tree because a *descendant* matched keep the filter, so an unrelated deep match still narrows the tree exactly as before, and behaviour with no search is unchanged.

```diff
- queryFilter={queryFilter}
+ queryFilter={queryFilter && queryFilter.flatMap((f) => f.result).includes(item.id) ? null : queryFilter}
```

## How it's applied

`skohub/skohub-vocabs-docker` runs the Gatsby build at `docker run` (source under `/app`), so `scripts/patch_search_tree.sh` runs **inside the container just before that build** (the workflow overrides the entrypoint to `patch && npm run container-build`). The script:

- rewrites exactly one line via `awk` (literal replace, no regex-escaping of `{ } &`);
- is **version-robust** — it recomputes the match set inline from the `queryFilter` prop rather than depending on the `filteredIds` local;
- **hard-fails** if the target line is missing or not unique, so if upstream SkoHub changes, the deploy stops with a clear message instead of silently shipping the old behaviour.

## Testing

- Verified the target line (`queryFilter={queryFilter}`) is unique in the component and that the `awk` transform changes that single line and nothing else.
- Traced the render path: matched parent stays expanded with children now present (each child collapsed with a working plus); deep-only matches still narrow; no-search output is byte-identical.

To verify on the deployed site after merge: **Actions → "Build and deploy…" → Run workflow**, then search "Barriers" — the concept should now expand to its children.
