### PR TITLE
Add a 'View in the Connectivity Hub' link to every term page

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -56,10 +56,13 @@ jobs:
           mkdir -p public && chmod 777 public
           # The image builds the site with Gatsby at run time (CMD `npm run
           # container-build`, source under /app). We override the entrypoint to
-          # first apply scripts/patch_search_tree.sh — which fixes SkoHub's search
-          # so a matched parent concept shows its subtree — and then run that same
-          # build. The patch hard-fails if the upstream source moved, so a broken
-          # patch stops the deploy instead of silently shipping the old behaviour.
+          # first apply our build-time patches and then run that same build:
+          #   - patch_search_tree.sh    fixes SkoHub's search so a matched parent
+          #     concept shows its subtree;
+          #   - patch_concept_hub_link.sh adds a "View in the Connectivity Hub"
+          #     link to every term page (deterministic from the concept UUID).
+          # Each patch hard-fails if the upstream source moved, so a broken patch
+          # stops the deploy instead of silently shipping the old behaviour.
           docker run --rm \
             --entrypoint /bin/sh \
             -v "$PWD/public:/app/public" \
@@ -67,8 +70,9 @@ jobs:
             -v "$PWD/.env:/app/.env" \
             -v "$PWD/config.yaml:/app/config.yaml" \
             -v "$PWD/scripts/patch_search_tree.sh:/tmp/patch_search_tree.sh:ro" \
+            -v "$PWD/scripts/patch_concept_hub_link.sh:/tmp/patch_concept_hub_link.sh:ro" \
             skohub/skohub-vocabs-docker:latest \
-            -c "sh /tmp/patch_search_tree.sh && npm run container-build"
+            -c "sh /tmp/patch_search_tree.sh && sh /tmp/patch_concept_hub_link.sh && npm run container-build"
 
       - name: Reclaim ownership of the built site
         # The SkoHub container runs as root, so it writes public/ as root. The

--- a/scripts/patch_concept_hub_link.sh
+++ b/scripts/patch_concept_hub_link.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# Patch SkoHub's concept page component so every term links back to its *dynamic*
+# representation in the weADAPT Connectivity Hub.
+#
+# WHY. The static SkoHub site is a mirror of the vocabulary that lives upstream in
+# the Connectivity Hub. Each term page here (e.g. .../terms/<uuid>.html) has a
+# living counterpart in the hub's viewer, e.g. for "Early warning systems (EWS)":
+#   https://connectivity-hub.weadapt.org/?resource=<encoded jsonld url>&teaser_resource=false
+# Reviewers browsing the taxonomy asked to jump from a term straight to that live
+# view. The link is fully deterministic from the concept's UUID, which is the last
+# path segment of the concept id (http://connectivity-hub.com/terms/<uuid>), so we
+# don't need any extra data in concepts.ttl — we build it at render time.
+#
+# Concept.jsx renders only a fixed set of SKOS properties (definition, notes,
+# related, *Match, ...) and has no generic "see also"/external-link slot, so a plain
+# triple in the data would not surface as a link. We therefore inject the link into
+# the component itself, right under the concept URI.
+#
+# HOW. skohub/skohub-vocabs-docker builds the site with Gatsby at `docker run` time
+# (CMD `npm run container-build`, source at /app), so this runs inside the container
+# just before that build — see .github/workflows/pages.yml, chained after
+# patch_search_tree.sh. It inserts one JSX block after a unique anchor line and
+# hard-fails if that anchor is missing / not unique (i.e. upstream SkoHub changed and
+# the patch needs a re-check) rather than silently shipping an un-patched site. It is
+# idempotent: a second run detects the marker and exits 0.
+set -eu
+
+f=/app/src/components/Concept.jsx
+# Anchor: the concept-URI element, rendered once per concept page.
+needle='<ConceptURI id={concept.id} />'
+marker='connectivity-hub-live-link'
+
+# --- The API host that backs the Connectivity Hub viewer. -------------------------
+# `api-uat` is the UAT/staging host used in the original request; the production host
+# `api.connectivity-hub.com` serves the same JSON-LD. Change this one value to switch.
+hub_api_host='api-uat.connectivity-hub.com'
+# ----------------------------------------------------------------------------------
+
+if [ ! -f "$f" ]; then
+  echo "PATCH ERROR: $f not found — the skohub-vocabs image layout changed." >&2
+  exit 1
+fi
+
+# Idempotent: if we've already injected the link, do nothing.
+if grep -F "$marker" "$f" >/dev/null 2>&1; then
+  echo "PATCH OK: Connectivity Hub link already present in $f — skipping."
+  exit 0
+fi
+
+count=$(grep -F -c "$needle" "$f" || true)
+if [ "$count" != "1" ]; then
+  echo "PATCH ERROR: expected exactly 1 occurrence of '$needle' in $f, found ${count}." >&2
+  echo "Upstream SkoHub changed; re-check scripts/patch_concept_hub_link.sh against the new source." >&2
+  exit 1
+fi
+
+# The JSX block to insert after the anchor line. Single-quoted heredoc: backticks,
+# ${...} and {} are written verbatim (no shell expansion). The href is computed from
+# concept.id at render time: last path segment = the term UUID.
+block_tmp=$(mktemp)
+cat > "$block_tmp" <<'EOF'
+      {/* connectivity-hub-live-link: jump to this term's live view in the weADAPT Connectivity Hub */}
+      <p className="hubLink" style={{ margin: "0.5rem 0" }}>
+        <a
+          target="_blank"
+          rel="noreferrer"
+          href={`https://connectivity-hub.weadapt.org/?resource=${encodeURIComponent(
+            `https://__HUB_API_HOST__/api/keyword/${concept.id
+              .split("/")
+              .filter(Boolean)
+              .pop()}.jsonld`
+          )}&teaser_resource=false`}
+        >
+          View in the Connectivity Hub ↗
+        </a>
+      </p>
+EOF
+
+# Substitute the configurable API host into the block.
+sed "s|__HUB_API_HOST__|${hub_api_host}|g" "$block_tmp" > "$block_tmp.host" && mv "$block_tmp.host" "$block_tmp"
+
+# Insert the block immediately after the (unique) anchor line.
+awk -v needle="$needle" -v blockfile="$block_tmp" '
+  { print }
+  index($0, needle) > 0 {
+    while ((getline line < blockfile) > 0) print line
+    close(blockfile)
+  }
+' "$f" > "$f.patched" && mv "$f.patched" "$f"
+rm -f "$block_tmp"
+
+if ! grep -F "$marker" "$f" >/dev/null; then
+  echo "PATCH ERROR: verification failed — Connectivity Hub link not present after edit." >&2
+  exit 1
+fi
+
+echo "PATCH OK: Connectivity Hub live-link injected into $f (host: ${hub_api_host})."


### PR DESCRIPTION
Answers the request to link each taxonomy term to its **dynamic representation** in the weADAPT Connectivity Hub.

## What
Every SkoHub concept page gets a **"View in the Connectivity Hub ↗"** link, right under the concept URI. Example — the *Early warning systems (EWS)* page now links to:

```
https://connectivity-hub.weadapt.org/?resource=https%3A%2F%2Fapi-uat.connectivity-hub.com%2Fapi%2Fkeyword%2F2605af32-4fdf-4847-ae26-4dcac5d01622.jsonld&teaser_resource=false
```

(byte-for-byte the URL from the request.)

## How
The link is **deterministic from the concept UUID** — the last path segment of `concept.id` (`http://connectivity-hub.com/terms/<uuid>`) — so **no extra data is added to `concepts.ttl`**; it is computed at render time.

`Concept.jsx` renders only a fixed set of SKOS properties and has no generic external-link/`seeAlso` slot, so a plain triple would not surface as a link. This is therefore a **build-time JSX patch** (`scripts/patch_concept_hub_link.sh`), chained after `patch_search_tree.sh` in `pages.yml`, in the same style as the existing patch:
- hard-fails if the upstream anchor line moved (so a stale patch stops the deploy instead of silently shipping an un-patched site);
- idempotent (skips if already applied).

Verified locally against the real upstream `Concept.jsx`: anchor matches exactly once, block injects cleanly, re-run is a no-op, and the generated URL is identical to the target.

## One decision to confirm — UAT vs production host
The link currently points at **`api-uat.connectivity-hub.com`** (the host in the original example). The **production** host `api.connectivity-hub.com` serves the same JSON-LD (both verified 200 + identical content). Since this is a public site, you may prefer production. It is a **one-line switch** — the `hub_api_host` constant at the top of `scripts/patch_concept_hub_link.sh`.

Note: needs a `pages.yml` run to appear on the live site.